### PR TITLE
add bearer token for todoist sync

### DIFF
--- a/src/main/java/me/escoffier/timeless/todoist/Todoist.java
+++ b/src/main/java/me/escoffier/timeless/todoist/Todoist.java
@@ -24,6 +24,7 @@ public interface Todoist {
 
     @POST
     @Path("/sync/v9/sync")
+    @ClientHeaderParam(name = "Authorization", value = "{lookupAuth}")
     SyncResponse sync(SyncRequest request);
 
     @POST


### PR DESCRIPTION
by adding bearer token on sync todoist dont complain about bad CSRF token...