### PR TITLE
feat: add optional inboxid to google

### DIFF
--- a/src/main/java/me/escoffier/timeless/inboxes/google/Account.java
+++ b/src/main/java/me/escoffier/timeless/inboxes/google/Account.java
@@ -11,13 +11,15 @@ public class Account {
     private final Calendar calendar;
     private final Drive drive;
     private final String email;
+    private final int inboxid;
 
-    Account(String name, String email, Gmail gmail, Calendar calendar, Drive drive) {
+    Account(String name, String email, Gmail gmail, Calendar calendar, Drive drive, int inboxid) {
         this.name = name;
         this.email = email;
         this.gmail = gmail;
         this.calendar = calendar;
         this.drive = drive;
+        this.inboxid = inboxid;
     }
 
     public String name() {
@@ -38,5 +40,9 @@ public class Account {
 
     public String email() {
         return email;
+    }
+
+    public int inboxid() {
+        return inboxid;
     }
 }

--- a/src/main/java/me/escoffier/timeless/inboxes/google/GAccount.java
+++ b/src/main/java/me/escoffier/timeless/inboxes/google/GAccount.java
@@ -1,0 +1,10 @@
+package me.escoffier.timeless.inboxes.google;
+
+import io.smallrye.config.WithDefault;
+
+public interface GAccount {
+
+    @WithDefault("0")
+    int inboxid();
+
+}

--- a/src/main/java/me/escoffier/timeless/inboxes/google/GAccounts.java
+++ b/src/main/java/me/escoffier/timeless/inboxes/google/GAccounts.java
@@ -1,0 +1,12 @@
+package me.escoffier.timeless.inboxes.google;
+
+import java.util.Map;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
+
+@ConfigMapping(prefix = "google")
+public interface GAccounts {
+@WithParentName 
+    Map<String, GAccount> accounts();
+}

--- a/src/main/java/me/escoffier/timeless/inboxes/google/StarredThread.java
+++ b/src/main/java/me/escoffier/timeless/inboxes/google/StarredThread.java
@@ -53,11 +53,8 @@ public class StarredThread {
     }
 
     String link() {
-        int inboxId = 0;
-        if (account.name().equalsIgnoreCase("redhat")) {
-            inboxId = 1;
-        }
-
+        int inboxId = account().inboxid();
+    
         return String
                 .format("https://mail.google.com/mail/u/%d/#inbox/%s", inboxId,
                         message.getId()

--- a/timeless-example.yaml
+++ b/timeless-example.yaml
@@ -21,8 +21,11 @@ github:
     - jbang: https://github.com/jbangdev
   username: maxandersen
 
-google:
-  accounts: personal,redhat
+google: 
+    personal:
+      inboxid: 1
+    redhat:
+      inboxid: 0
 
 pocket:
   consumer-key: "pocket-secret-token"


### PR DESCRIPTION
currently gmail assumes that if account is "redhat" the inboxid is 0 otherwise 1.

This fixes that by allowing to explicilty set it per google account.

```
google:
	accounts: redhat,personal
```

becomes:

```
google:
	redhat:
		inboxid: 0
    personal:
		inboxid: 1
```
